### PR TITLE
Send all eram messages to the MCA Feedback area.

### DIFF
--- a/src/components/MessageComposeArea.tsx
+++ b/src/components/MessageComposeArea.tsx
@@ -5,6 +5,7 @@ import {
   closeAllWindows,
   defaultWindowPositions,
   FULLSCREEN_WINDOWS,
+  invertNumpadSelector,
   mcaFeedbackSelector,
   pushZStack,
   setIsFullscreen,
@@ -40,7 +41,7 @@ import { aclCleanup } from "~redux/thunks/aclCleanup";
 import { isAclSortKey, SORT_KEYS_NOT_IMPLEMENTED } from "types/aclSortData";
 import { addAclEntryByFid } from "~redux/thunks/entriesThunks";
 import socket from "~socket";
-import { GI_EXPR } from "~/utils/constants";
+import { D_SIDE_ENUM, GI_EXPR } from "~/utils/constants";
 import { toggleAltimeter, toggleMetar } from "~redux/slices/weatherSlice";
 import { printFlightStrip } from "components/PrintableFlightStrip";
 import { appWindow } from "@tauri-apps/api/window";
@@ -77,6 +78,8 @@ export const MessageComposeArea = () => {
   const options = useWindowOptions("MESSAGE_COMPOSE_AREA");
 
   const feedbackRows = mcaFeedbackString.toUpperCase().split("\n");
+
+  const invertNumpad = useRootSelector(invertNumpadSelector);
 
   const onMcaMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {
     if (zStack.indexOf("MESSAGE_COMPOSE_AREA") < zStack.length - 1) {
@@ -206,31 +209,12 @@ export const MessageComposeArea = () => {
     });
 
     const eramMessage: ProcessEramMessageDto = {
-      source: EramPositionType.DSide,
+      source: D_SIDE_ENUM,
       elements,
-      invertNumericKeypad: false,
+      invertNumericKeypad: invertNumpad,
     };
 
-    try {
-      const result = await hubActions.sendEramMessage(eramMessage);
-      if (result) {
-        if (result.isSuccess) {
-          // If successful, accept the command with feedback
-          const feedbackMessage = result.feedback.length > 0 ? result.feedback.join("\n") : mcaInputValue;
-          dispatch(setMcaAcceptMessage(feedbackMessage));
-
-          if (result.response) {
-            dispatch(setMraMessage(result.response));
-            dispatch(openWindowThunk("MESSAGE_RESPONSE_AREA"));
-          }
-        } else {
-          const rejectMessage = result?.feedback?.length > 0 ? `REJECT\n${result.feedback.join("\n")}` : `REJECT\n${mcaInputValue}`;
-          dispatch(setMcaRejectMessage(rejectMessage));
-        }
-      }
-    } catch (error) {
-      reject(`\n${error?.message || "Command failed"}`);
-    }
+    await hubActions.sendEramMessage(eramMessage);
   };
 
   const handleWeatherRequest = async (args: string[], input: string) => {

--- a/src/components/Status.tsx
+++ b/src/components/Status.tsx
@@ -9,6 +9,9 @@ import { FloatingWindow } from "components/utils/FloatingWindow";
 import { HubConnectionState } from "@microsoft/signalr";
 import { VERSION } from "~/utils/constants";
 import { envSelector, hubConnectedSelector, logout, logoutThunk } from "~redux/slices/authSlice";
+import { invertNumpadSelector, setInvertNumpad } from "~/redux/slices/appSlice";
+import optionStyles from "css/optionMenu.module.scss";
+import clsx from "clsx";
 
 export const Status = () => {
   const [showOptions, setShowOptions] = useState(false);
@@ -21,6 +24,7 @@ export const Status = () => {
   const dispatch = useRootDispatch();
   const { disconnectHub } = useHubConnector();
   const hubConnected = useRootSelector(hubConnectedSelector);
+  const invertNumpad = useRootSelector(invertNumpadSelector);
 
   const toggleSocket = () => {
     if (isConnected) {
@@ -41,6 +45,12 @@ export const Status = () => {
     <FloatingWindow title="STATUS" optionsHeaderTitle="STATUS" width="40ch" window="STATUS" showOptions={showOptions} setShowOptions={setShowOptions}>
       <div>vEDST version {VERSION}</div>
       <div>{hubConnected && environment ? `Connected to ${environment.name}` : "NOT CONNECTED"}</div>
+      <div className={optionStyles.row}>
+        <div className={clsx(optionStyles.col, "flex")} onMouseDown={() => dispatch(setInvertNumpad(!invertNumpad))}>
+          <div className={clsx(optionStyles.indicator, { selected: invertNumpad })} />
+          Invert Numpad
+        </div>
+      </div>
       <div>
         <EdstButton onMouseDown={logOutHandler} content="LOG OUT / CHANGE ENVIRONMENT" />
       </div>

--- a/src/hooks/useHubActions.ts
+++ b/src/hooks/useHubActions.ts
@@ -1,7 +1,7 @@
 import type { ApiLocation } from "types/apiTypes/apiLocation";
 import type { HoldAnnotations } from "types/hold/holdAnnotations";
 import { useRootDispatch } from "~redux/hooks";
-import { setMcaAcceptMessage } from "~redux/slices/appSlice";
+import { setMcaAcceptMessage, setMcaRejectMessage, setMraMessage } from "~redux/slices/appSlice";
 import type { CreateOrAmendFlightplanDto } from "types/apiTypes/CreateOrAmendFlightplanDto";
 import type { AircraftId } from "types/aircraftId";
 import { useHubConnection } from "hooks/useHubConnection";
@@ -10,6 +10,7 @@ import type { HubConnection } from "@microsoft/signalr";
 import { HubConnectionState } from "@microsoft/signalr";
 import type { EramMessageProcessingResultDto } from "~/types/apiTypes/EramMessageProcessingResultDto";
 import { useHubConnector } from "./useHubConnector";
+import { openWindowThunk } from "~/redux/thunks/openWindowThunk";
 
 async function ensureConnected(hubConnection: HubConnection | null, connectHub: () => Promise<void>): Promise<HubConnection | null> {
   if (!hubConnection) {
@@ -67,8 +68,24 @@ export const useHubActions = () => {
     invokeHub(hubConnection, connectHub, (connection) => connection.invoke<void>("sendPrivateMessage", aircraftId, message));
 
   const sendEramMessage = async (eramMessage: ProcessEramMessageDto) =>
-    invokeHub<EramMessageProcessingResultDto>(hubConnection, connectHub, (connection) =>
-      connection.invoke<EramMessageProcessingResultDto>("processEramMessage", eramMessage));
+    invokeHub<EramMessageProcessingResultDto>(hubConnection, connectHub, async (connection) => {
+      const result = await connection.invoke<EramMessageProcessingResultDto>("processEramMessage", eramMessage);
+      if (result) {
+        if (result.isSuccess) {
+          const feedbackMessage = result.feedback.length > 0 ? result.feedback.join("\n") : "Command accepted";
+          dispatch(setMcaAcceptMessage(feedbackMessage));
+
+          if (result.response) {
+            dispatch(setMraMessage(result.response));
+            dispatch(openWindowThunk("MESSAGE_RESPONSE_AREA"));
+          }
+        } else {
+          const rejectMessage = result.feedback.length > 0 ? `REJECT\n${result.feedback.join("\n")}` : "REJECT\nCommand failed";
+          dispatch(setMcaRejectMessage(rejectMessage));
+        }
+      }
+      return result;
+    });
 
   return {
     generateFrd,

--- a/src/redux/slices/appSlice.ts
+++ b/src/redux/slices/appSlice.ts
@@ -53,6 +53,7 @@ type AppState = {
   outages: OutageEntry[];
   headerTop: boolean;
   fsdIsConnected: boolean;
+  invertNumpad: boolean;
 };
 
 const getScreenDimensions = () => ({
@@ -150,6 +151,7 @@ const initialState: AppState = {
   outages: [],
   headerTop: loadHeaderPosition(),
   fsdIsConnected: true,
+  invertNumpad: false,
 };
 
 const appSlice = createSlice({
@@ -217,6 +219,9 @@ const appSlice = createSlice({
     // removes outage message at index
     delOutageMessage(state, action: PayloadAction<string>) {
       state.outages = state.outages.filter((outage) => outage.id !== action.payload);
+    },
+    setInvertNumpad(state, action: PayloadAction<boolean>) {
+      state.invertNumpad = action.payload;
     },
   },
 });
@@ -312,6 +317,7 @@ export const {
   setFsdIsConnected,
   addOutageMessage,
   delOutageMessage,
+  setInvertNumpad,
 } = appSlice.actions;
 export default appSlice.reducer;
 
@@ -335,3 +341,4 @@ export const outageSelector = (state: RootState) => state.app.outages;
 export const windowsSelector = (state: RootState) => state.app.windows;
 export const headerTopSelector = (state: RootState) => state.app.headerTop;
 export const fsdIsConnectedSelector = (state: RootState) => state.app.fsdIsConnected;
+export const invertNumpadSelector = (state: RootState) => state.app.invertNumpad;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,5 @@
+import { EramPositionType } from "~/types/apiTypes/ProcessEramMessageDto";
+
 export const WEATHER_REFRESH_RATE = 120000; // 2 minutes
 export const SPA_INDICATOR = "^";
 export const COMPLETED_CHECKMARK_SYMBOL = "\u2713";
@@ -5,6 +7,8 @@ export const DOWNLINK_SYMBOL = "\u00BB";
 export const OPLUS_SYMBOL = "\u2295";
 export const VCI_SYMBOL = "\u2719";
 export const CPDLC_VCI = "\u2720";
+
+export const D_SIDE_ENUM = EramPositionType.DSide;
 
 const ALT_EXPR = /[0-5]?[1-9][05]/;
 export const ALTITUDE_VALIDATION_EXPRESSIONS = {


### PR DESCRIPTION
To better simulate the system, all entries on the UI that invoke ERAM messages to the hub now display feedback in the MCA feedback area.

In addition, I've cleaned up the ERAM message construction such that the `source` and `invertNumericKeypad` fields are populated globally. This involved adding a "invert numpad" option to the status menu.

Depends on #70 