### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,7 +44,7 @@ jobs:
           VITE_VERSION: ${{ steps.version-number.outputs.VERSION_NUMBER }}
         run: npm run build
       - name: Archive build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
No additional changes are required for migration because we are not using any features affected by the update