### PR TITLE
[HubContext] fix race-condition

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,10 @@ import LoginProvider from "~/login/Login";
 import PrivateRoute from "~/routes/PrivateRoute";
 import { useRootDispatch } from "~redux/hooks";
 import { getVnasConfig } from "~redux/slices/authSlice";
-import { ToastContainer, toast } from 'react-toastify';
+import { ToastContainer, toast } from "react-toastify";
 
-import 'react-toastify/dist/ReactToastify.css';
+import "react-toastify/dist/ReactToastify.css";
+import { HubContextProvider } from "./contexts/HubContext";
 
 const App = () => {
   const dispatch = useRootDispatch();
@@ -18,13 +19,15 @@ const App = () => {
 
   return (
     <BrowserRouter>
-      <ToastContainer />
-      <Routes>
-        <Route path="/login" element={<LoginProvider />} />
-        <Route path="/" element={<PrivateRoute />}>
-          <Route path="/" element={<EdstProvider />} />
-        </Route>
-      </Routes>
+      <HubContextProvider>
+        <ToastContainer />
+        <Routes>
+          <Route path="/login" element={<LoginProvider />} />
+          <Route path="/" element={<PrivateRoute />}>
+            <Route path="/" element={<EdstProvider />} />
+          </Route>
+        </Routes>
+      </HubContextProvider>
     </BrowserRouter>
   );
 };

--- a/src/Edst.tsx
+++ b/src/Edst.tsx
@@ -148,9 +148,7 @@ const Edst = () => {
 const EdstProvider = () => (
   <React.StrictMode>
     <SocketContextProvider>
-      <HubContextProvider>
-        <Edst />
-      </HubContextProvider>
+      <Edst />
     </SocketContextProvider>
   </React.StrictMode>
 );

--- a/src/login/Login.tsx
+++ b/src/login/Login.tsx
@@ -111,9 +111,7 @@ const Login = () => {
 const LoginProvider = () => (
   <React.StrictMode>
     <SocketContextProvider>
-      <HubContextProvider>
-        <Login />
-      </HubContextProvider>
+      <Login />
     </SocketContextProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
Moves the hub  context provider up a layer so that it's not unloaded between the transition from /login to Edst.tsx and vice versa. This was breaking in production once minified.