### PR TITLE
[HubContext] only subscribe to topics using primary position

### DIFF
--- a/src/contexts/HubContext.tsx
+++ b/src/contexts/HubContext.tsx
@@ -119,8 +119,11 @@ export const HubContextProvider = ({ children }: { children: ReactNode }) => {
           });
           console.log(`Joined session ${sessionInfo.id}`);
 
-          await hubConnection.invoke<void>("subscribe", new ApiTopic("FlightPlans", sessionInfo.positions[0].facilityId));
-          await hubConnection.invoke<void>("subscribe", new ApiTopic("EramTracks", sessionInfo.positions[0].facilityId));
+          const primaryFacilityId = sessionInfo.positions.find((p) => p.isPrimary)?.facilityId;
+          if (primaryFacilityId) {
+            await hubConnection.invoke<void>("subscribe", new ApiTopic("FlightPlans", primaryFacilityId));
+            await hubConnection.invoke<void>("subscribe", new ApiTopic("EramTracks", primaryFacilityId));
+          }
           dispatch(setHubConnected(true));
         } else {
           throw new Error("Hub connection not in Connected state");


### PR DESCRIPTION
If you have multiple secondary windows activated, they may be earlier in the array of positions in your session than the primary session, and the hub only allows for subscribing to a topic on the primary session.